### PR TITLE
Adding before and after parameters

### DIFF
--- a/third_party/time_select/ft.time_select.php
+++ b/third_party/time_select/ft.time_select.php
@@ -23,7 +23,7 @@ class Time_select_ft extends EE_Fieldtype {
 
 	var $info = array(
 		'name'		=> 'Time Select',
-		'version'	=> '1.0.1'
+		'version'	=> '1.0.2'
 	);
  
  			
@@ -167,6 +167,10 @@ class Time_select_ft extends EE_Fieldtype {
 	
 	function replace_tag($data, $params = array(), $tagdata = FALSE)
 	{
+		/*
+			Before and after parameter. 'Starts at '.'12:45'.' hour' 
+		    to avoid advanced conditionals like {if field_name != ""} ... {/if}
+		*/
 		$before = (isset($params['before']) ? $params['before'].' ' : '');
 		$after  = (isset($params['after'])  ? ' '.$params['after'] : '');
 		


### PR DESCRIPTION
I'm trying to shave of milliseconds by avoiding advanced conditionals.
Including before and after parameter so you don't need:

```
{if field_name !=""}<span>Event starts at: {field_name format="G:i"} hour</span>{/if}
// now becomes
{field_name before="<span>Event starts at:" format="G:i" after="hour</span>"}
```

Time_select doesn't use EE date formatting, which would have allowed formats like:

```
{field_name format="<em>TODAY</em><span>%j</span><strong>%F</strong>"}
```
