### PR TITLE
Update accepts_content_type to be more explicit

### DIFF
--- a/ee3/user/addons/time_select/ft.time_select.php
+++ b/ee3/user/addons/time_select/ft.time_select.php
@@ -49,12 +49,16 @@ class Time_select_ft extends EE_Fieldtype {
 		);
 	}
 
+	public function accepts_content_type($name)
+    	{
+        	$acceptedTypes = [
+            		'channel',
+            		'grid',
+            		'blocks/1',
+        	];
 
-	function accepts_content_type($name)
-	{
-		return true;
-	}
-	
+        	return in_array($name, $acceptedTypes);
+    	}
 
 	function display_settings($data)
 	{	


### PR DESCRIPTION
Bloqs does not just assume that any fieldtype returning true here is supported. Fieldtype developers should opt in to Bloqs support for a variety of reasons. The same goes for the new Fluid type. Adding a content type to the list shows that the fieldtype has been tested to support that content type.