### PR TITLE
Add default for time_increments

### DIFF
--- a/ee3/user/addons/time_select/ft.time_select.php
+++ b/ee3/user/addons/time_select/ft.time_select.php
@@ -260,7 +260,8 @@ class Time_select_ft extends EE_Fieldtype {
 			case '5min':
 				$mins = array('' => '--', 0 => '00', 5 => '5', 10 => '10', 15 => '15', 20 => '20', 25 => '25', 30 => '30', 35 => '35', 40 => '40', 45 => '45', 50 => '50', 55 => '55');
 				break;
-			case '15min':
+            default:
+            case '15min':
 				$mins = array('' => '--', 0 => '00', 15 => '15', 30 => '30', 45 => '45');
 				break;
 			case '30min':


### PR DESCRIPTION
make sure $mins array is set (display field warning), even when no settings for time_increments